### PR TITLE
fix: setuptools_scm missing

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: ff66c9142cae46317fb8b58e7acf59c963721e4f2a1505830cce99b57e78f091
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -22,6 +22,8 @@ requirements:
   host:
     - python
     - pip !=22.1.0
+    - setuptools
+    - setuptools_scm
   run:
     - python
     - numpy >=1.21


### PR DESCRIPTION

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* Reset the build number to `0` (if the version changed)
* [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* Ensured the license file is being packaged.

Manually pushed to fork this time, instead of expecting `gh` to ask, which either it didn't or I bypassed the question out of habit (quite possible).

See https://github.com/conda-forge/scikit-hep-feedstock/pull/18.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
